### PR TITLE
Fix quote in card text link and legacy previews pointing to reborn cards

### DIFF
--- a/src/components/cards/CardDetails.vue
+++ b/src/components/cards/CardDetails.vue
@@ -61,6 +61,7 @@
           <div class="leading-snug text-sm">
             <card-codes
               :content="details.text"
+              :is-legacy="showLegacy"
               is-card-effect></card-codes>
           </div>
         </div>

--- a/src/components/shared/Card.vue
+++ b/src/components/shared/Card.vue
@@ -43,6 +43,7 @@
           <div class="leading-snug" :class="$style['effect-text']">
             <card-codes
               :content="card.text"
+              :is-legacy="card.is_legacy"
               is-card-effect></card-codes>
           </div>
         </div>

--- a/src/components/shared/CardCodes.vue
+++ b/src/components/shared/CardCodes.vue
@@ -13,12 +13,17 @@ export default {
       type: Boolean,
       default: false,
     },
+    isLegacy: {
+      type: Boolean,
+      default: false,
+    }
   },
   setup (props) {
     // Setup accepts a reactive `props` object and can return a render function, so this
     // functionally allows us to compile arbitrary HTML into Vue components
+    const cardText = props.isCardEffect ? parseEffectText(props.content, props.isLegacy) : parseCardText(props.content, false, props.isLegacy)
     return compile(
-      props.isCardEffect ? parseEffectText(props.content) : parseCardText(props.content)
+      cardText
     )
   },
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -113,7 +113,7 @@ export function parseCardText (text, ensureParagraphs=false, isLegacy=false) {
     '&': '&amp;',
     '<': '&lt;',
     '"': '&quot;',
-    "'": '&#39;'
+    "'": '\\&#39;'
   }
   if (unescapedHTML.test(text)) {
     text = text.replace(unescapedHTML, (char) => {
@@ -144,11 +144,11 @@ export function parseCardText (text, ensureParagraphs=false, isLegacy=false) {
     }
   )
   // Parse card codes
-  text = text.replace(/\[\[(\*?)((?:[a-z -]|&#39;)+)(?::([a-z]+))?\]\]|( - )/ig, (input, isImage, primary, secondary, dash) => {
+  text = text.replace(/\[\[(\*?)((?:[a-z -]|\\&#39;)+)(?::([a-z]+))?\]\]|( - )/ig, (input, isImage, primary, secondary, dash) => {
     if (dash) {
       return ' <i class="divider"><span class="alt-text">-</span></i> '
     }
-    let lowerPrimary = primary.toLowerCase().replace('&#39;', '')
+    let lowerPrimary = primary.toLowerCase().replace('\\&#39;', '')
     secondary = secondary && secondary.toLowerCase()
     if (['discard', 'exhaust'].indexOf(lowerPrimary) > -1) {
       return `<i class="phg-${lowerPrimary}" title="${primary}"></i>`
@@ -171,10 +171,7 @@ export function parseCardText (text, ensureParagraphs=false, isLegacy=false) {
     } else if (secondary) {
       return `<i>${lowerPrimary} ${secondary}</i>`
     } else {
-      if (isLegacy) {
-        return `<card-link :card="{name: '${primary}', stub: '${lowerPrimary.replace(/ +/g, '-')}', is_legacy: true}"></card-link>`
-      }
-      return `<card-link :card="{name: '${primary}', stub: '${lowerPrimary.replace(/ +/g, '-')}'}"></card-link>`
+      return `<card-link :card="{name: '${primary}', stub: '${lowerPrimary.replace(/ +/g, '-')}', is_legacy: ${isLegacy}}"></card-link>`
     }
     return `<i class="phg-${lowerPrimary}-${secondary}" title="${primary}${secondary ? ' ' + secondary : ''}"><span class="alt-text">${input}</span></i>`
   })


### PR DESCRIPTION
This PR fixes two issues.

## 1 - Closes #11 - quotes in card text link

When card text have a quote in one of the linked text (for example, Harold Westraven's has `Hunter's mask`), the output would raise a vue compile error. To fix it, it just needs to have an extra `\` (itself escaped) in the output string.

Before:
![image](https://user-images.githubusercontent.com/762494/102715698-2157d580-42cf-11eb-88b7-8ef688973fc9.png)

After: 
![image](https://user-images.githubusercontent.com/762494/102715702-2b79d400-42cf-11eb-90f1-7c28cabe14cb.png)


## 2 - Legacy card links were pointing to reborn cards

Legacy flag wasn't passed down to card link component, resulting in Legacy card previews linking to reborn cards, and sometimes resulting in errors for cards not existing in Reborn.

Before: 
![image](https://user-images.githubusercontent.com/762494/102715777-8ad7e400-42cf-11eb-86f2-61d90b11ad6c.png)

After:
![image](https://user-images.githubusercontent.com/762494/102715803-a5aa5880-42cf-11eb-9cd3-70366d2dbddf.png)

