### PR TITLE
Add deck detail page

### DIFF
--- a/src/components/decks/Deck.vue
+++ b/src/components/decks/Deck.vue
@@ -31,6 +31,7 @@
 
 <script>
 import { parseISO, formatDistanceToNowStrict } from 'date-fns'
+import { getPhoenixbornImageUrl } from '/src/utils.js'
 import DeckCardsPreview from './DeckCardsPreview.vue'
 import DeckDice from './DeckDice.vue'
 import UserBadge from '../users/UserBadge.vue'
@@ -63,7 +64,7 @@ export default {
       }, 0)
     },
     phoenixbornImagePath () {
-      return this.deck.is_legacy ? `https://cdn.ashes.live/legacy/images/cards/${this.deck.phoenixborn.stub}-slice.jpg` : `https://cdn.ashes.live/images/phoenixborn-badges/${this.deck.phoenixborn.stub}.jpg`
+      return getPhoenixbornImageUrl(this.deck.phoenixborn.stub, false, this.deck.is_legacy)
     }
   },
 }

--- a/src/components/decks/Deck.vue
+++ b/src/components/decks/Deck.vue
@@ -1,6 +1,7 @@
 <template>
   <div
-    class="border border-gray bg-white mt-4 mb-4 deck-item pl-12"
+    class="border border-gray bg-white mt-4 mb-4 pl-12"
+    :class="$style.deckItem"
     :style="`background-image: url(${phoenixbornImagePath})`">
     <div class="p-2 text-xs">
       <div class="m-0 font-bold text-xl flex flex-col sm:flex-row">
@@ -20,7 +21,7 @@
         <span class="text-lg">
           <card-link :card="deck.phoenixborn"></card-link>
         </span>
-        <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? 'deck-not-full' : '']">
+        <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? $style.deckNotFull : '']">
           {{ cardsCount }}/30
         </span>
       </div>
@@ -69,12 +70,12 @@ export default {
   },
 }
 </script>
-<style scoped>
-.deck-not-full {
+<style lang="postcss" module>
+.deckNotFull {
   color: var(--color-red);
 }
 
-.deck-item {
+.deckItem {
   background-repeat: no-repeat;
 }
 </style>

--- a/src/components/decks/DeckCardsPreview.vue
+++ b/src/components/decks/DeckCardsPreview.vue
@@ -1,11 +1,11 @@
 <template>
-  <div class="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-2">
-    <deck-cards-type-list :cards="this.readySpells" typeLabel="Ready Spells" />
-    <deck-cards-type-list :cards="this.allies" typeLabel="Allies" />
-    <deck-cards-type-list :cards="this.actionSpells" typeLabel="Action Spells" />
-    <deck-cards-type-list :cards="this.reactionSpells" typeLabel="Reaction Spells" />
-    <deck-cards-type-list :cards="this.alterationSpells" typeLabel="Alteration Spells" />
-    <deck-cards-type-list :cards="this.conjurations" typeLabel="Conjurations" />
+  <div :class="[ columnLayout ? 'text-base': 'grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-6 gap-2']">
+    <deck-cards-type-list :cards="this.readySpells" class="mb-4" typeLabel="Ready Spells" />
+    <deck-cards-type-list :cards="this.allies" class="mb-4" typeLabel="Allies" />
+    <deck-cards-type-list :cards="this.actionSpells" class="mb-4" typeLabel="Action Spells" />
+    <deck-cards-type-list :cards="this.reactionSpells" class="mb-4" typeLabel="Reaction Spells" />
+    <deck-cards-type-list :cards="this.alterationSpells" class="mb-4" typeLabel="Alteration Spells" />
+    <deck-cards-type-list :cards="this.conjurations" class="mb-4" typeLabel="Conjurations" />
   </div>
 </template>
 
@@ -16,7 +16,11 @@ const filterCardsByType = (cards, type) => cards.filter(card => card.type === ty
 
 export default {
   name: 'DeckCardsPreview',
-  props: ['cards', 'conjurations'],
+  props: {
+    cards: null,
+    conjurations: null,
+    columnLayout: false
+  },
   components: {
     DeckCardsTypeList,
   },

--- a/src/components/decks/DeckCardsTypeList.vue
+++ b/src/components/decks/DeckCardsTypeList.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="cards && cards.length" class="mt-1">
     <i :class="[typeIcon]"></i>
-    <strong class="text-base font-medium pl-1">{{typeLabel}}</strong> ({{ count }})
+    <strong class="text-base font-normal pl-1">{{typeLabel}}</strong> <span class="text-gray-darker">({{ count }})</span>
     <ul class="mt-1">
       <li v-for="(card, index) of cards" :key="index">
         <span>{{ card.count }}x <card-link :card="card"></card-link></span>

--- a/src/components/decks/DeckDescription.vue
+++ b/src/components/decks/DeckDescription.vue
@@ -1,0 +1,21 @@
+<script>
+import { compile } from 'vue'
+import { parseCardText } from '/src/utils.js'
+
+export default {
+  name: 'DeckDescription',
+  props: {
+    content: {
+      type: String,
+      required: true,
+    },
+  },
+  setup (props) {
+    // Setup accepts a reactive `props` object and can return a render function, so this
+    // functionally allows us to compile arbitrary HTML into Vue components
+    return compile(
+      parseCardText(props.content)
+    )
+  },
+}
+</script>

--- a/src/components/decks/DeckDescription.vue
+++ b/src/components/decks/DeckDescription.vue
@@ -9,13 +9,14 @@ export default {
       type: String,
       required: true,
     },
+    isLegacy: false
   },
   setup (props) {
     // Setup accepts a reactive `props` object and can return a render function, so this
     // functionally allows us to compile arbitrary HTML into Vue components
     return compile(
       `<div class="deckDescription">` +
-        parseCardText(props.content) +
+        parseCardText(props.content, true, props.isLegacy) +
         '</div>'
     )
   },

--- a/src/components/decks/DeckDescription.vue
+++ b/src/components/decks/DeckDescription.vue
@@ -14,8 +14,18 @@ export default {
     // Setup accepts a reactive `props` object and can return a render function, so this
     // functionally allows us to compile arbitrary HTML into Vue components
     return compile(
-      parseCardText(props.content)
+      `<div class="deckDescription">` +
+        parseCardText(props.content) +
+        '</div>'
     )
   },
 }
 </script>
+<style>
+
+.deckDescription ul {
+  list-style-type: disc;
+  padding-left: 40px;
+}
+
+</style>

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -63,7 +63,7 @@
     </div>
     <hr />
     <h1>Description</h1>
-    <DeckDescription :content="deck.description" />
+    <DeckDescription :content="deck.description" :isLegacy="deck.is_legacy"/>
   </div>
 </template>
 

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -15,7 +15,7 @@
       <div
         class="mb-4 deckContainer col-span-2 flex flex-row">
         <img :src="phoenixbornImagePath" />
-        <div class="text-xs">
+        <div class="flex-grow text-xs">
           <div class="text-3xl">
             <card-link :card="deck.phoenixborn"></card-link>
           </div>
@@ -43,13 +43,21 @@
           <deck-cards-preview :cards="deck.cards" :conjurations="deck.conjurations" :columnLayout="true"/>
         </div>
       </div>
-      <div class="flex flex-col">
-          <span class="text-sm">
+      <div>
+        <div>
+          <span class="text-gray-darker w-20 inline-block">Author:</span>
+          <span>
             <user-badge :user="deck.user" />
           </span>
-          <span class="text-sm float-right text-gray-darker">
-            Last updated: {{ lastUpdatedDateFormatted }} ago
-          </span>
+        </div>
+        <div>
+          <span class="text-gray-darker w-20 inline-block">Updated:</span>
+          <span>{{ lastUpdatedDateFormatted }} ago</span>
+        </div>
+        <div>
+          <span class="text-gray-darker w-20 inline-block">Requires:</span>
+          <span>{{ formatReleases }}</span>
+        </div>
       </div>
     </div>
     <hr />
@@ -95,7 +103,7 @@ export default {
   },
   computed: {
     phoenixbornImagePath () {
-      return this.deck.is_legacy ? `https://cdn.ashes.live/legacy/images/cards/${this.deck.phoenixborn.stub}-slice.jpg` : `https://cdn.ashes.live/images/phoenixborn/${this.deck.phoenixborn.stub}.jpg`
+      return this.deck.is_legacy ? `https://cdn.ashes.live/legacy/images/cards/${this.deck.phoenixborn.stub}-large.jpg` : `https://cdn.ashes.live/images/phoenixborn/${this.deck.phoenixborn.stub}.jpg`
     },
     lastUpdatedDateFormatted () {
       return formatDistanceToNowStrict(parseISO(this.deck.modified))
@@ -105,6 +113,10 @@ export default {
         return prev + card.count
       }, 0)
     },
+    formatReleases() {
+      const releaseNames = this.releases.map(r => r.name)
+      return releaseNames.join(', ')
+    }
   },
 }
 </script>

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -69,7 +69,7 @@
 <script>
 import { compile } from 'vue'
 import { parseISO, formatDistanceToNowStrict } from 'date-fns'
-import { request, parseCardText } from '/src/utils.js'
+import { request, parseCardText, getPhoenixbornImageUrl } from '/src/utils.js'
 import DeckCardsPreview from './DeckCardsPreview.vue'
 import DeckDescription from './DeckDescription.vue'
 import DeckDice from './DeckDice.vue'
@@ -103,7 +103,7 @@ export default {
   },
   computed: {
     phoenixbornImagePath () {
-      return this.deck.is_legacy ? `https://cdn.ashes.live/legacy/images/cards/${this.deck.phoenixborn.stub}-large.jpg` : `https://cdn.ashes.live/images/phoenixborn/${this.deck.phoenixborn.stub}.jpg`
+      return getPhoenixbornImageUrl(this.deck.phoenixborn.stub, true, this.deck.is_legacy)
     },
     lastUpdatedDateFormatted () {
       return formatDistanceToNowStrict(parseISO(this.deck.modified))

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -1,18 +1,98 @@
 <template>
-  <div>
-    TODO: implement deck detail
+<div v-if="error">
+    <h1 class="phg-discard">No deck found</h1>
+
+    <p class="text-lg">
+      Sorry, this does not appear to be a valid deck!
+    </p>
+  </div>
+  <div v-else-if="!deck">
+    <h1 class="phg-side-action text-gray"><i class="fas fa-circle-notch fa-spin"></i> Loading...</h1>
+  </div>
+  <div v-else>
+    <h1 class="phg-side-action">{{ deck.title }}</h1>
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+      <div
+        class="mb-4 deck-container col-span-2 flex flex-row">
+        <img :src="phoenixbornImagePath" />
+        <div class="text-xs">
+          <div class="text-3xl">
+            <card-link :card="deck.phoenixborn"></card-link>
+          </div>
+          <div class="m-0 font-bold text-xl flex flex-col sm:flex-row">
+            <deck-dice :dice="deck.dice" />
+          </div>
+          <hr class="mb-4 mt-4" />
+          <div class="mb-1">
+            
+            <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? 'deck-not-full' : '']">
+              {{ cardsCount }}/30
+            </span>
+          </div>
+          <deck-cards-preview :cards="deck.cards" :conjurations="deck.conjurations" />
+        </div>
+      </div>
+      <div class="flex flex-col">
+          <span class="text-sm">
+            <user-badge :user="deck.user" />
+          </span>
+          <span class="text-sm float-right text-gray-darker">
+            Last updated: {{ lastUpdatedDateFormatted }} ago
+          </span>
+      </div>
+    </div>
   </div>
 </template>
 
 <script>
+import { request } from '/src/utils.js'
+import { parseISO, formatDistanceToNowStrict } from 'date-fns'
+import DeckCardsPreview from './DeckCardsPreview.vue'
+import DeckDice from './DeckDice.vue'
+import UserBadge from '../users/UserBadge.vue'
+
 export default {
   name: 'DeckDetails',
   props: ['id'],
   components: {
+    DeckCardsPreview,
+    DeckDice,
+    UserBadge,
   },
   data () {
     return {
+      deck: null,
+      releases: null,
+      error: false,
     }
+  },
+  beforeMount () {
+    request(`/v2/decks/${this.id}`).then(response => {
+      this.deck = response.data.deck
+      this.releases = response.data.releases
+      // And set the site title
+      document.title = `${this.deck.title} - Ashes.live`
+    }).catch(error => {
+      this.error = true
+    })
+  },
+  computed: {
+    phoenixbornImagePath () {
+      return this.deck.is_legacy ? `https://cdn.ashes.live/legacy/images/cards/${this.deck.phoenixborn.stub}-slice.jpg` : `https://cdn.ashes.live/images/phoenixborn/${this.deck.phoenixborn.stub}.jpg`
+    },
+    lastUpdatedDateFormatted () {
+      return formatDistanceToNowStrict(parseISO(this.deck.modified))
+    },
+    cardsCount () {
+      return this.deck.cards.reduce((prev, card) => {
+        return prev + card.count
+      }, 0)
+    },
   },
 }
 </script>
+<style scoped>
+.deck-container {
+  background-repeat: no-repeat;
+}
+</style>

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -13,23 +13,34 @@
     <h1 class="phg-side-action">{{ deck.title }}</h1>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div
-        class="mb-4 deck-container col-span-2 flex flex-row">
+        class="mb-4 deckContainer col-span-2 flex flex-row">
         <img :src="phoenixbornImagePath" />
         <div class="text-xs">
           <div class="text-3xl">
             <card-link :card="deck.phoenixborn"></card-link>
           </div>
-          <div class="m-0 font-bold text-xl flex flex-col sm:flex-row">
+          <ul class="mb-2 mt-2 text-base">
+            <strong
+            v-if="deck.phoenixborn.battlefield !== undefined"
+            class="inline-block border border-red-light px-1">Battlefield {{ deck.phoenixborn.battlefield }}</strong>
+            <strong
+              v-if="deck.phoenixborn.life !== undefined"
+              class="inline-block border border-green-light px-1 mx-1">Life {{ deck.phoenixborn.life }}</strong>
+            <strong
+              v-if="deck.phoenixborn.spellboard !== undefined"
+              class="inline-block border border-blue-dark px-1">Spellboard {{ deck.phoenixborn.spellboard }}</strong>
+          </ul>
+          <div class="mb-2 mt-2 font-bold text-xl flex flex-col sm:flex-row">
             <deck-dice :dice="deck.dice" />
           </div>
           <hr class="mb-4 mt-4" />
           <div class="mb-1">
-            
-            <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? 'deck-not-full' : '']">
+            <span class="text-lg font-bold">Cards</span>
+            <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? 'deckNotFull' : 'text-gray-darker']">
               {{ cardsCount }}/30
             </span>
           </div>
-          <deck-cards-preview :cards="deck.cards" :conjurations="deck.conjurations" />
+          <deck-cards-preview :cards="deck.cards" :conjurations="deck.conjurations" :columnLayout="true"/>
         </div>
       </div>
       <div class="flex flex-col">
@@ -41,13 +52,18 @@
           </span>
       </div>
     </div>
+    <hr />
+    <h1>Description</h1>
+    <DeckDescription :content="deck.description" />
   </div>
 </template>
 
 <script>
-import { request } from '/src/utils.js'
+import { compile } from 'vue'
 import { parseISO, formatDistanceToNowStrict } from 'date-fns'
+import { request, parseCardText } from '/src/utils.js'
 import DeckCardsPreview from './DeckCardsPreview.vue'
+import DeckDescription from './DeckDescription.vue'
 import DeckDice from './DeckDice.vue'
 import UserBadge from '../users/UserBadge.vue'
 
@@ -56,6 +72,7 @@ export default {
   props: ['id'],
   components: {
     DeckCardsPreview,
+    DeckDescription,
     DeckDice,
     UserBadge,
   },
@@ -92,7 +109,12 @@ export default {
 }
 </script>
 <style scoped>
-.deck-container {
+.deckContainer {
   background-repeat: no-repeat;
 }
+
+.deckNotFull {
+  color: var(--color-red);
+}
+
 </style>

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -70,7 +70,7 @@
 <script>
 import { compile } from 'vue'
 import { parseISO, formatDistanceToNowStrict } from 'date-fns'
-import { request, parseCardText, getPhoenixbornImageUrl } from '/src/utils.js'
+import { request, getPhoenixbornImageUrl } from '/src/utils.js'
 import DeckCardsPreview from './DeckCardsPreview.vue'
 import DeckDescription from './DeckDescription.vue'
 import DeckDice from './DeckDice.vue'

--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -13,7 +13,8 @@
     <h1 class="phg-side-action">{{ deck.title }}</h1>
     <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
       <div
-        class="mb-4 deckContainer col-span-2 flex flex-row">
+        class="mb-4 col-span-2 flex flex-row"
+        :class="$style.deckContainer">
         <img :src="phoenixbornImagePath" />
         <div class="flex-grow text-xs">
           <div class="text-3xl">
@@ -36,7 +37,7 @@
           <hr class="mb-4 mt-4" />
           <div class="mb-1">
             <span class="text-lg font-bold">Cards</span>
-            <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? 'deckNotFull' : 'text-gray-darker']">
+            <span class="text-sm float-right font-bold" :class="[ cardsCount != 30 ? $style.deckNotFull : 'text-gray-darker']">
               {{ cardsCount }}/30
             </span>
           </div>
@@ -120,7 +121,7 @@ export default {
   },
 }
 </script>
-<style scoped>
+<style lang="postcss" module>
 .deckContainer {
   background-repeat: no-repeat;
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -2,6 +2,8 @@ import axios from 'axios'
 import Nanobar from 'nanobar'
 import { diceList } from './constants.js'
 
+const ASHES_CDN_BASE_URL = 'https://cdn.ashes.live'
+
 /**
  * request(options)
  *
@@ -257,4 +259,17 @@ export function parseEffectText (text, isLegacy=false) {
   // Bold ability names (&#39; is apostrophe)
   text = text.replace(/(?:<p>|^)((?:[a-z 0-9]|&#39;)+:)(?= \w| <i class="phg-)/ig, '<p><strong>$1</strong>')
   return text
+}
+
+/**
+ * Returns phoenixborn image url from the CDN.
+ *
+ * @param {str} stub Phoenixborn card name
+ * @param {str} isLarge If the image to be returned should be the large version 
+ * @param {bool} isLegacy If the card is from the Ashes 1.0 set as opposed to the Reborn set
+ */
+export function getPhoenixbornImageUrl(stub, isLarge = false, isLegacy = false) {
+  return isLegacy ?
+    `${ASHES_CDN_BASE_URL}/legacy/images/cards/${stub}-${isLarge ? 'large' : 'slice'}.jpg` :
+    `${ASHES_CDN_BASE_URL}/images/phoenixborn${isLarge ? '' : '-badges'}/${stub}.jpg`
 }


### PR DESCRIPTION
Adds the deck detail page, based on the static page I received.

Still to be done:
- export as text
- view history
- comments

Also I'm not 100% sure what can be expected as the input for the description so for now I've just copied what's done for the card text.
Feedback appreciated, I think the layout is still not perfect but still think it deserves a review.

Screenshots:
![image](https://user-images.githubusercontent.com/762494/104850538-a7276a80-58e7-11eb-8601-8f29a263e86d.png)
![image](https://user-images.githubusercontent.com/762494/104850550-af7fa580-58e7-11eb-8f06-2c83d76584b3.png)
