### PR TITLE
Feature: publishing decks

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and community site for the card game Ashes Reborn. The site uses the following f
 to make developing easier:
 
 * [VueJS 3](https://v3.vuejs.org) for Javascript logic
-* [Tailwind CSS 1](https://tailwindcss.com/) for utility-first styling
+* [Tailwind CSS 2](https://tailwindcss.com/) for utility-first styling
 
 ## Installation
 

--- a/src/components/Home.vue
+++ b/src/components/Home.vue
@@ -73,10 +73,18 @@
         </li>
         <li class="flex flex-nowrap">
           <span class="pr-2">
+            <i class="far fa-check-square"></i>
+          </span>
+          <span>
+            Publishing decks and TTS integration
+          </span>
+        </li>
+        <li class="flex flex-nowrap">
+          <span class="pr-2">
             <i class="far fa-square"></i>
           </span>
           <span class="text-gray-dark">
-            Publishing decks; Ashteki and TTS integration
+            Private snapshots; Ashteki integration
           </span>
         </li>
         <li class="flex flex-nowrap">

--- a/src/components/decks/Builder.vue
+++ b/src/components/decks/Builder.vue
@@ -37,13 +37,18 @@
           <i class="fas fa-eye"></i>
           Preview
         </button>
-        <button class="btn btn-last mb-4" @click="exportDeck">
+        <button class="btn btn-inner" @click="exportDeck">
           <i class="fas fa-share-square"></i>
           Export...
+        </button>
+        <button class="btn btn-last mb-4 btn-green" @click="publishDeck" :disabled="invalidDeck">
+          <i class="far fa-plus-square"></i>
+          Publish...
         </button>
       </div>
     </transition-height>
     <deck-export-modal v-model:open="showExportModal" :deck="$store.state.builder.deck"></deck-export-modal>
+    <deck-publish-modal v-model:open="showPublishModal" :deck="$store.state.builder.deck"></deck-publish-modal>
     <div class="flex mb-2">
       <text-input
         class="flex-grow"
@@ -103,6 +108,7 @@
 import useHandleResponseError from '/src/composition/useHandleResponseError.js'
 import BuilderDeck from './BuilderDeck.vue'
 import DeckExportModal from './DeckExportModal.vue'
+import DeckPublishModal from './DeckPublishModal.vue'
 import LinkAlike from '../shared/LinkAlike.vue'
 import TextEditor from '../shared/TextEditor.vue'
 import TextInput from '../shared/TextInput.vue'
@@ -117,6 +123,7 @@ export default {
   components: {
     BuilderDeck,
     DeckExportModal,
+    DeckPublishModal,
     LinkAlike,
     TextEditor,
     TextInput,
@@ -129,6 +136,7 @@ export default {
     editingDescription: false,
     showActions: false,
     showExportModal: false,
+    showPublishModal: false,
     // Tracks whether the deckbuilder pane is open on small screens
     paneOpen: true,
   }),
@@ -172,7 +180,10 @@ export default {
       if (this.noPhoenixborn) return 'Phoenixborn required'
       if (this.isDirty) return 'Save your deck'
       return 'Deck is saved!'
-    }
+    },
+    invalidDeck () {
+      return this.$store.getters['builder/totalDice'] !== 10 || this.$store.getters['builder/totalCards'] !== 30 || this.$store.state.builder.isDirty || this.$store.state.builder.isSaving
+    },
   },
   methods: {
     choosePhoenixborn () {
@@ -219,6 +230,10 @@ export default {
         // The toggle button is only shown at screen sizes where the pan actually toggles
         document.body.style.overflow = 'hidden'
       }
+    },
+    publishDeck () {
+      this.showPublishModal = true
+      this.showActions = false
     },
   },
   watch: {

--- a/src/components/decks/Builder.vue
+++ b/src/components/decks/Builder.vue
@@ -94,7 +94,7 @@
           </button>
         </div>
       </div>
-      <builder-deck class="pb-16 xl:pb-0"></builder-deck>
+      <builder-deck class="pb-16 xl:pb-0" @close-pane="paneOpen = false"></builder-deck>
     </div>
   </section>
 </template>

--- a/src/components/decks/BuilderDeck.vue
+++ b/src/components/decks/BuilderDeck.vue
@@ -35,7 +35,13 @@
     <!-- TODO: do I want to implement the "Clear dice" and "Set filters" buttons? Not sure anyone actually used them... -->
     <hr class="mt-6 mb-4">
 
-    <h3>Cards <span class="text-gray">(<span :class="{'text-red': totalCards > 30}">{{ totalCards }} / 30</span>)</span></h3>
+    <div class="flex mb-4">
+      <h3 class="flex-grow m-0">Cards <span class="text-gray">(<span :class="{'text-red': totalCards > 30}">{{ totalCards }} / 30</span>)</span></h3>
+      <button class="text-lg text-black px-1" title="Add cards..." @click="addCards">
+        <i class="fas fa-plus"></i>
+        <span class="alt-text">Add cards...</span>
+      </button>
+    </div>
 
     <div v-for="section of deckSections" :key="section.title">
       <h4><i :class="typeClass(section.contents[0].type)"></i> {{ section.title }} <span class="text-gray">({{ section.count }})</span></h4>
@@ -87,6 +93,7 @@ export default {
     DieCounter,
     DeckQtyButtons,
   },
+  emits: ['closePane'],
   computed: {
     allDiceTypes () {
       return diceList
@@ -141,6 +148,10 @@ export default {
     },
     typeClass (type) {
       return typeToFontAwesome[type]
+    },
+    addCards () {
+      this.$emit('closePane')
+      this.$router.push('/cards/')
     },
   },
 }

--- a/src/components/decks/DeckPublishModal.vue
+++ b/src/components/decks/DeckPublishModal.vue
@@ -1,0 +1,110 @@
+<template>
+  <modal :open="open" @update:open="$emit('update:open', false)">
+    <div class="sm:w-96 sm:mx-auto">
+      <h2 class="phg-natural-power">Publish your deck</h2>
+
+      <p>After publishing your deck, you can continue to edit it privately; if you want to share your new edits, just publish it again!</p>
+
+      <form @submit.prevent="publishDeck">
+        <text-input
+          label="Title"
+          :placeholder="defaultTitle"
+          v-model="title"
+          class="mb-4"></text-input>
+        <text-editor
+          label="Description"
+          v-model="description"
+          class="mb-4"
+          @focus="description = ''"></text-editor>
+        <button class="btn btn-blue px-4 py-1 mb-4" :disabled="isSubmittingRequest" @click="publishDeck">Publish deck!</button>
+      </form>
+    </div>
+  </modal>
+</template>
+
+<script>
+import { request } from '/src/utils/index.js'
+import useHandleResponseError from '/src/composition/useHandleResponseError.js'
+import Modal from '../shared/Modal.vue'
+import TextEditor from '../shared/TextEditor.vue'
+import TextInput from '../shared/TextInput.vue'
+
+export default {
+  name: 'DeckPublishModal',
+  props: {
+    open: Boolean,
+    deck: {
+      required: true,
+    },
+  },
+  setup () {
+    // Standard composite containing { toast, handleResponseError }
+    return useHandleResponseError()
+  },
+  data: () => ({
+    _title: null,
+    _description: null,
+    isSubmittingRequest: false,
+  }),
+  emits: ['update:open'],
+  components: {
+    Modal,
+    TextEditor,
+    TextInput,
+  },
+  computed: {
+    title: {
+      get () {
+        return this._title || ''
+      },
+      set (value) {
+        this._title = value
+      },
+    },
+    defaultTitle () {
+      return this.deck.title || `Untitled ${this.deck.phoenixborn.name}`
+    },
+    description: {
+      get () {
+        return this._description || ''
+      },
+      set (value) {
+        this._description = value
+      },
+    },
+    defaultDescription () {
+      return this.deck.description
+    },
+  },
+  methods: {
+    publishDeck () {
+      if (this.isSubmittingRequest) return
+      const data = {
+        is_public: true,
+      }
+      if (this._title) {
+        data.title = this._title
+      }
+      if (this._description !== null) {
+        data.description = this._description
+      }
+      this.isSubmittingRequest = true
+      request(`/v2/decks/${this.deck.id}/snapshot`, {
+        method: 'post',
+        data: data,
+      }).then(() => {
+        this.toast.success('Your deck has been published!')
+        this.$emit('update:open', false)
+        this.$router.push({
+          name: 'DeckDetails',
+          params: { id: this.deck.id }
+        })
+      }).catch(error => {
+        this.handleResponseError(error)
+      }).finally(() => {
+        this.isSubmittingRequest = false
+      })
+    },
+  },
+}
+</script>

--- a/src/components/decks/PlayerDecks.vue
+++ b/src/components/decks/PlayerDecks.vue
@@ -9,7 +9,7 @@
       </router-link>
     </div>
     <div class="sm:order-1 flex-grow">
-      <p class="mt-0 mb-8"><span class="font-bold text-lg">By default, your decks are completely private.</span> When you are happy with your deck, you can create a public snapshot that will be visible to other players. After a snapshot is published, further edits to the deck will remain private until you create a new public snapshot.</p>
+      <p class="mt-0 mb-8"><span class="font-bold text-lg">By default, your decks are completely private.</span> When you are happy with your deck, you can publish it for other players to see. After a deck is published, further edits to the deck will remain private until you publish it again.</p>
     </div>
   </div>
   <div v-else>


### PR DESCRIPTION
Closes #54.

I opted to go with a really simple modal for the first iteration of deck publishing. Eventually, this is going to need to be a standalone page, I think (maybe part of the snapshots page?) but for now we just need to be able to push public snapshots so that people can share their decks.