### PR TITLE
Add "Preconstructed Decks Only" toggle to public deck listing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "Ashes.live",
-  "version": "2.0.0a2",
+  "version": "2.0.0a3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/components/decks/DeckListing.vue
+++ b/src/components/decks/DeckListing.vue
@@ -12,7 +12,7 @@
       :is-legacy="showLegacy"
     />
     <div v-if="!showMine" class="flex flex-col justify-center h-10 mb-4">
-      <toggle v-model="preconOnly"><span class="ml-2 text-sm">Pre-Constructed Only</span></toggle>
+      <toggle v-model="preconOnly"><span class="ml-2 text-sm">Preconstructed Only</span></toggle>
     </div>
   </div>
   <deck-table

--- a/src/components/decks/DeckListing.vue
+++ b/src/components/decks/DeckListing.vue
@@ -6,16 +6,15 @@
       v-model:search="filterText"
       :is-disabled="isDisabled"></clearable-search>
     <phoenixborn-picker
-      class="flex-auto h-10 mb-4 md:mb-0"
+      class="flex-auto h-10 mb-4 md:pr-4 md:mb-0"
       placeholder="Filter by Phoenixborn..."
       v-model:filter="phoenixborn"
       :is-legacy="showLegacy"
     />
-    <p v-if="!showMine">
-      <toggle v-model="preconOnly"></toggle>
-    </p>
+    <div v-if="!showMine" class="flex flex-col justify-center h-10 mb-4">
+      <toggle v-model="preconOnly"><span class="ml-2 text-sm">Pre-Constructed Only</span></toggle>
+    </div>
   </div>
-
   <deck-table
     :is-disabled="isDisabled"
     :decks="decks"
@@ -220,6 +219,7 @@ export default {
       const filterText = trimmed(this.filterText)
       if (this.phoenixborn) params.phoenixborn = this.phoenixborn
       if (filterText) params.q = filterText
+      if (this.preconOnly) params.show_preconstructed = true
       this.fetchDecks({ options: { params }, failureCallback })
     },
     loadNext () {

--- a/src/components/decks/DeckListing.vue
+++ b/src/components/decks/DeckListing.vue
@@ -62,13 +62,13 @@ export default {
     // This is the list of decks currently shown
     decks: null,
     deckCount: 0,
-    preconOnly: false
+    preconOnly: false,
   }),
   components: {
     DeckTable,
     ClearableSearch,
     PhoenixbornPicker,
-    Toggle
+    Toggle,
   },
   computed: {
     showLegacy () {
@@ -139,15 +139,7 @@ export default {
     watch(
       [
         () => this.phoenixborn,
-      ],
-      (curProps, prevProps) => {
-        this.offset = 0
-        this.filterList(() => {})
-      }
-    )
-    watch(
-      [
-        () => this.preconOnly,
+        () => this.preconOnly
       ],
       (curProps, prevProps) => {
         this.offset = 0

--- a/src/components/decks/DeckListing.vue
+++ b/src/components/decks/DeckListing.vue
@@ -11,6 +11,9 @@
       v-model:filter="phoenixborn"
       :is-legacy="showLegacy"
     />
+    <p v-if="!showMine">
+      <toggle v-model="preconOnly"></toggle>
+    </p>
   </div>
 
   <deck-table
@@ -36,6 +39,7 @@ import ClearableSearch from '../shared/ClearableSearch.vue'
 import { debounce, request } from '/src/utils/index.js'
 import { trimmed } from '/src/utils/text.js'
 import PhoenixbornPicker from '../shared/PhoenixbornPicker.vue'
+import Toggle from '../shared/Toggle.vue'
 
 const DECKS_PER_PAGE = 30;
 
@@ -59,11 +63,13 @@ export default {
     // This is the list of decks currently shown
     decks: null,
     deckCount: 0,
+    preconOnly: false
   }),
   components: {
     DeckTable,
     ClearableSearch,
     PhoenixbornPicker,
+    Toggle
   },
   computed: {
     showLegacy () {
@@ -140,6 +146,15 @@ export default {
         this.filterList(() => {})
       }
     )
+    watch(
+      [
+        () => this.preconOnly,
+      ],
+      (curProps, prevProps) => {
+        this.offset = 0
+        this.filterList(() => {})
+      }
+    )
     // Trigger initial listing load
     this.filterList()
   },
@@ -148,6 +163,7 @@ export default {
       this.filterText = ''
       this.phoenixborn = null
       this.offset = 0
+      this.preconOnly = false
     },
     fetchDecks ({endpoint = null, options = {}, failureCallback = null} = {}) {
       if (!endpoint) {


### PR DESCRIPTION
Fixes #58

- Adds toggle to the deck listing, use v-if to hide it when viewing own decks

- Used existing toggle component and put it inline with the other filters 
  ![image](https://user-images.githubusercontent.com/39933023/113047038-cc014f00-916e-11eb-99d4-bd926192841c.png)