### PR TITLE
seperate summons toggle

### DIFF
--- a/src/components/cards/card_browser/FilterText.vue
+++ b/src/components/cards/card_browser/FilterText.vue
@@ -1,0 +1,22 @@
+<template>
+  <i :class="typeIcon(type)"></i> <span class="hidden xl:inline">{{ text || type.split(' ')[0] }}</span>
+</template>
+
+<script>
+import { typeToFontAwesome } from '/src/constants.js'
+
+export default {
+  name: 'FilterIcon',
+  props: {
+    type: String,
+    text: String,
+  },
+  methods: {
+    typeIcon (targetType) {
+      if (targetType === 'Summon') return 'fas fa-plus-square'
+      const typeClass = typeToFontAwesome[targetType]
+      return typeClass ? typeClass : 'fa-question-circle'
+    },
+  }
+}
+</script>

--- a/src/components/cards/card_browser/TypeFilter.vue
+++ b/src/components/cards/card_browser/TypeFilter.vue
@@ -29,7 +29,7 @@
       @click="setOnlySummoners(true)"
       :class="{ active: onlySummoners }"
       class="btn py-1 px-2 font-normal text-sm btn-last">
-      <filter-text type="Summon" text="Only Summoning Cards"/>
+      <filter-text type="Summon" text="Summons"/>
     </button>
   </div>
 </template>

--- a/src/components/cards/card_browser/TypeFilter.vue
+++ b/src/components/cards/card_browser/TypeFilter.vue
@@ -19,17 +19,10 @@
     </span>
     <button
       :disabled="isDisabled"
-      @click="setOnlySummoners(false)"
-      :class="{ active: !onlySummoners }"
-      class="btn py-1 px-2 font-normal text-sm btn-first">
-      All
-    </button>
-    <button
-      :disabled="isDisabled"
-      @click="setOnlySummoners(true)"
-      :class="{ active: onlySummoners }"
-      class="btn py-1 px-2 font-normal text-sm btn-last">
-      <filter-text type="Summon" text="Only Summoning Cards"/>
+      @click="toggleType('summon')"
+      :class="{ active: isTypeActive('summon') }"
+      class="btn py-1 px-2 font-normal text-sm">
+      <filter-text type="Summon" text="Summons" />
     </button>
   </div>
 </template>
@@ -61,9 +54,6 @@ export default {
         ['Conjuration', 'conjurations'],
       ]
     },
-    onlySummoners () {
-      return this.isTypeActive('summon');
-    }
   },
   methods: {
     typeIcon (targetType) {
@@ -84,10 +74,6 @@ export default {
         this.$emit('update:filterList', Array.from(types))
       }
     },
-    setOnlySummoners (value) {
-      if (value === this.onlySummoners) return;
-      return this.toggleType('summon');
-    }
   },
 }
 </script>

--- a/src/components/cards/card_browser/TypeFilter.vue
+++ b/src/components/cards/card_browser/TypeFilter.vue
@@ -19,10 +19,17 @@
     </span>
     <button
       :disabled="isDisabled"
-      @click="toggleType('summon')"
-      :class="{ active: isTypeActive('summon') }"
-      class="btn py-1 px-2 font-normal text-sm">
-      <filter-text type="Summon" text="Summons" />
+      @click="setOnlySummoners(false)"
+      :class="{ active: !onlySummoners }"
+      class="btn py-1 px-2 font-normal text-sm btn-first">
+      All
+    </button>
+    <button
+      :disabled="isDisabled"
+      @click="setOnlySummoners(true)"
+      :class="{ active: onlySummoners }"
+      class="btn py-1 px-2 font-normal text-sm btn-last">
+      <filter-text type="Summon" text="Only Summoning Cards"/>
     </button>
   </div>
 </template>
@@ -54,6 +61,9 @@ export default {
         ['Conjuration', 'conjurations'],
       ]
     },
+    onlySummoners () {
+      return this.isTypeActive('summon');
+    }
   },
   methods: {
     typeIcon (targetType) {
@@ -74,6 +84,10 @@ export default {
         this.$emit('update:filterList', Array.from(types))
       }
     },
+    setOnlySummoners (value) {
+      if (value === this.onlySummoners) return;
+      return this.toggleType('summon');
+    }
   },
 }
 </script>

--- a/src/components/cards/card_browser/TypeFilter.vue
+++ b/src/components/cards/card_browser/TypeFilter.vue
@@ -1,27 +1,44 @@
 <template>
   <div class="flex flex-nowrap" role="group" aria-label="Filter by card type">
+    <span class="pr-4">
+      <button
+        v-for="(curType, index) of cardTypes" :key="curType[1]"
+        class="btn py-1 px-2 font-normal text-sm"
+        :class="{
+          'btn-first': index === 0,
+          'btn-inner': index !== 0 && index < cardTypes.length - 1,
+          'btn-last': index === cardTypes.length - 1,
+          active: isTypeActive(curType[1]),
+        }"
+        :disabled="isDisabled"
+        :title="curType[0]"
+        @click="toggleType(curType[1])">
+          <filter-text :type="curType[0]" />
+        <span v-if="isTypeActive(curType[1])" class="alt-text absolute"> (active)</span>
+      </button>
+    </span>
     <button
-      v-for="(curType, index) of cardTypes" :key="curType[1]"
-      class="btn py-1 px-2 font-normal text-sm"
-      :class="{
-        'btn-first': index === 0,
-        'btn-inner': index !== 0 && index < cardTypes.length - 1,
-        'btn-last': index === cardTypes.length - 1,
-        active: isTypeActive(curType[1]),
-      }"
       :disabled="isDisabled"
-      :title="curType[0]"
-      @click="toggleType(curType[1])">
-      <i :class="typeIcon(curType[0])"></i> <span class="hidden xl:inline">{{ curType[0].split(' ')[0] }}</span>
-      <span v-if="isTypeActive(curType[1])" class="alt-text absolute"> (active)</span>
+      @click="setOnlySummoners(false)"
+      :class="{ active: !onlySummoners }"
+      class="btn py-1 px-2 font-normal text-sm btn-first">
+      All
+    </button>
+    <button
+      :disabled="isDisabled"
+      @click="setOnlySummoners(true)"
+      :class="{ active: onlySummoners }"
+      class="btn py-1 px-2 font-normal text-sm btn-last">
+      <filter-text type="Summon" text="Only Summoning Cards"/>
     </button>
   </div>
 </template>
 
 <script>
-import { typeToFontAwesome } from '/src/constants.js'
+import FilterText from './FilterText.vue';
 
 export default {
+  components: { FilterText },
   name: 'TypeFilter',
   props: {
     isDisabled: Boolean,
@@ -40,10 +57,12 @@ export default {
         ['Reaction Spell', 'reaction_spell'],
         ['Alteration Spell', 'alteration_spell'],
         ['Ready Spell', 'ready_spell'],
-        ['Summon', 'summon'],
         ['Phoenixborn', 'phoenixborn'],
         ['Conjuration', 'conjurations'],
       ]
+    },
+    onlySummoners () {
+      return this.isTypeActive('summon');
     }
   },
   methods: {
@@ -65,6 +84,10 @@ export default {
         this.$emit('update:filterList', Array.from(types))
       }
     },
+    setOnlySummoners (value) {
+      if (value === this.onlySummoners) return;
+      return this.toggleType('summon');
+    }
   },
 }
 </script>


### PR DESCRIPTION
Addresses https://github.com/onecrayon/ashes.live/issues/59

I'm not super happy with the text [here](https://github.com/onecrayon/ashes.live/compare/seperate-summons-toggle?expand=1#diff-c7af61f90f066ed3a36a63321c756c6b93e61d664b978e9cbddbb6a9cf72f034R32), so if anyone has better ideas, I'm all ears. I opted against "show summons" because I feel that it implies that summonsing cards will _only_ be shown if it is selected.