### PR TITLE
fix nested popup behavior

### DIFF
--- a/src/store/cardDetails.js
+++ b/src/store/cardDetails.js
@@ -7,16 +7,17 @@
  */
 
 const state = () => ({
-  displayedId: null,
+  displayedIds: [],
 })
 
 const mutations = {
-  setDisplayedId(state, { id }) {
-    state.displayedId = id
+  addDisplayedId(state, { id }) {
+    state.displayedIds.push(id);
   },
-  unsetDisplayedId(state, { id }) {
-    if (state.displayedId !== id) return
-    state.displayedId = null
+  clearSelfAndDescendents(state, { id }) {
+   const index = state.displayedIds.findIndex(x => x === id);
+   if (index === -1) return;
+   state.displayedIds.splice(index);
   }
 }
 


### PR DESCRIPTION
Closes #73..

The target here is:
* the "descendents" of a popup should close when it is clicked
* only a single child of a given card should be visible at a time
* hovering/tapping outside of the tree should clear everything
* we should still only be able to have one root level popup visible at a time

I focused most of my testing around the summons for indiglow creeper and ghostly mount.