### PR TITLE
Updated builder save logic to do a final save upon exit

### DIFF
--- a/src/components/decks/Builder.vue
+++ b/src/components/decks/Builder.vue
@@ -195,7 +195,7 @@ export default {
     },
     saveDeck (forceSave = false) {
       if (this.noPhoenixborn || this.isSaving) return
-      this.$store.dispatch('builder/SAVE_DECK', forceSave)
+      this.$store.dispatch('builder/SAVE_DECK', { forceSave })
     },
     openDescriptionEditor () {
       this.editingDescription = true


### PR DESCRIPTION
Now that everything is debounced, we could potentially exit prior to our final debounced save triggering, which will lead to weirdness. Changed things to fix this issue:

* Upon resetting the builder, issue an immediate forced save if things are dirty
* Added flag to the save action to allow skipping deck repopulation (necessary if the builder is closing)
* Tweaked the sequencing of promise resolution such that force saves will resolve the outer promise after the save is complete (unlike default behavior of queuing up the debounce and then resolving immediately)