### PR TITLE
Ticket 102 - added ability to find decks by card

### DIFF
--- a/src/components/cards/CardDetails.vue
+++ b/src/components/cards/CardDetails.vue
@@ -105,7 +105,7 @@
               </span>
             </card-meta-row>
             <card-meta-row label="Usage:">
-              <strong>{{ usage.users }} user<span v-if="usage.users != 1">s</span></strong> <span v-if="usage.users != 1">have</span><span v-else>has</span> this card in <strong>{{ usage.decks }} deck<span v-if="usage.decks != 1">s</span></strong>
+              <strong>{{ usage.users }} user<span v-if="usage.users != 1">s</span></strong> <span v-if="usage.users != 1">have</span><span v-else>has</span> this card in <router-link :to="{'name': 'Decks', query: { card: card.stub }}"><strong>{{ usage.decks }} deck<span v-if="usage.decks != 1">s</span></strong></router-link>
             </card-meta-row>
             <card-meta-row label="Release:">
               <router-link v-if="preconstructedDeck && preconstructedDeck.title == card.release.name" :to="{'name': 'DeckDetails', params: { id: preconstructedDeck.id }}">{{ card.release.name }}</router-link>

--- a/src/components/decks/DeckListing.vue
+++ b/src/components/decks/DeckListing.vue
@@ -27,7 +27,7 @@
     :currentPage="currentPage"
     :totalPage="totalPage"
     :show-mine="showMine"
-    :have-filters="!!filterText || !!phoenixborn"></deck-table>
+    :have-filters="!!filterText || !!phoenixborn || !!card"></deck-table>
 </template>
 
 <script>
@@ -63,6 +63,7 @@ export default {
     decks: null,
     deckCount: 0,
     preconOnly: false,
+    card: null,
   }),
   components: {
     DeckTable,
@@ -94,6 +95,7 @@ export default {
       this.phoenixborn = this.$route.query.phoenixborn
       this.offset = integerQueryParam(this.$route.query.offset)
       this.preconOnly = booleanQueryParam(this.$route.query.preconstructed)
+      this.card = this.$route.query.card
     }
 
     let firstPreviousProps = null
@@ -156,6 +158,7 @@ export default {
       this.phoenixborn = null
       this.offset = 0
       this.preconOnly = false
+      this.card = null
     },
     fetchDecks ({endpoint = null, options = {}, failureCallback = null} = {}) {
       if (!endpoint) {
@@ -178,6 +181,9 @@ export default {
         if (this.preconOnly) {
           // Setting to null makes it an opt-in parameter that doesn't show a value
           query.preconstructed = null
+        }
+        if (this.card) {
+          query.card = this.card
         }
         // Only push to router is query has changed. In the case of scrolling, we don't want to push as
         // it's the same url but pushing to the router will make it scroll back to top
@@ -217,6 +223,7 @@ export default {
       if (this.phoenixborn) params.phoenixborn = this.phoenixborn
       if (filterText) params.q = filterText
       if (this.preconOnly) params.show_preconstructed = true
+      if (this.card) params.card = [this.card]
       this.fetchDecks({ options: { params }, failureCallback })
     },
     loadNext () {


### PR DESCRIPTION
Simple change to utilize the filtering functionality already built into the API. On the card detail page, the number of decks the card is usable in will now be clickable, and will take the user to a list of public decks using the card.