### PR TITLE
Fix: additional padding for deck detail header icon

### DIFF
--- a/src/components/decks/DeckDetails.vue
+++ b/src/components/decks/DeckDetails.vue
@@ -10,7 +10,7 @@
     <h1 class="phg-main-action text-gray"><i class="fas fa-circle-notch fa-spin"></i> Loading...</h1>
   </div>
   <div v-else>
-    <h1 class="phg-main-action mb-6" :class="{'italic font-normal': !deck.title}">{{ title }}</h1>
+    <h1 class="phg-main-action mb-6 pl-px" :class="{'italic font-normal': !deck.title}">{{ title }}</h1>
     <p v-if="showMine" class="text-l border-2 border-orange rounded bg-inexhaustible px-4 py-2 mb-8">
       <i class="far fa-eye-slash"></i> You are viewing your most recent private save for this deck.
       <router-link v-if="hasPublishedSnapshot" :to="{name: 'DeckDetails', params: {id: deck.id}}">View public URL.</router-link>

--- a/src/components/decks/SharedDeckDetails.vue
+++ b/src/components/decks/SharedDeckDetails.vue
@@ -3,7 +3,7 @@
     <h1 class="phg-natural-power text-gray"><i class="fas fa-circle-notch fa-spin"></i> Loading...</h1>
   </div>
   <div v-else>
-    <h1 class="phg-natural-power mb-6" :class="{'italic font-normal': !deck.title}">{{ title }}</h1>
+    <h1 class="phg-natural-power mb-6 pl-px" :class="{'italic font-normal': !deck.title}">{{ title }}</h1>
     <div class="lg:flex">
       <div class="mb-4 lg:pl-8 lg:w-1/3 lg:order-2">
         <p class="border-2 border-orange rounded bg-inexhaustible px-4 py-2 mb-8">


### PR DESCRIPTION
Added a pixel of padding to ensure the font rendering doesn't mis-align the icon and the deck image on deck detail pages